### PR TITLE
Setup deployment to GitHub package registry for Gradle artifacts

### DIFF
--- a/.github/workflows/gh-registry.yml
+++ b/.github/workflows/gh-registry.yml
@@ -2,6 +2,20 @@ name: Publish strongbox-examples to the GitHub Package Registry
 on:
   [ push ]
 jobs:
+  publish-hello-strongbox-gradle:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - run: gradle build
+        working-directory: 'hello-strongbox-gradle'
+      - run: gradle publish
+        working-directory: 'hello-strongbox-gradle'
+        env:
+          GITHUB_USERNAME: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   publish-hello-strongbox-npm:
     runs-on: ubuntu-latest
     steps:

--- a/hello-strongbox-gradle/build.gradle
+++ b/hello-strongbox-gradle/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id("maven-publish")
+}
+
 apply plugin: 'java'
 apply plugin: 'maven'
 
@@ -9,8 +13,37 @@ compileJava {
 
 description = "Example project that shows how to use gradle to build and deploy artifacts to Strongbox"
 
-ext.username = System.getProperty('credentials.username') != null ? System.getProperty('credentials.username') : mavenUser
-ext.password = System.getProperty('credentials.password') != null ? System.getProperty('credentials.password') : mavenPassword
+// publishing to GitHub Package Registry
+publishing {
+    repositories {
+        maven {
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/strongbox/strongbox-examples")
+            credentials {
+                // GITHUB_USERNAME is automatically provived by the actions/setup-java action
+                username = project.findProperty("gpr.user") ?: System.getenv("GITHUB_USERNAME")
+                // GITHUB_TOKEN is automatically provived by GitHub for every repository
+                password = project.findProperty("gpr.key") ?: System.getenv("GITHUB_TOKEN")
+            }
+        }
+    }
+    publications {
+        gpr(MavenPublication) {
+            pom {
+                description = "Example project that shows how to use gradle to build and deploy artifacts to Strongbox"
+            }
+
+            groupId = "org.carlspring.strongbox.examples"
+            artifactId = "hello-strongbox-gradle"
+            version = "1.0-SNAPSHOT"
+
+            from components.java
+        }
+    }
+}
+
+ext.username = System.getProperty('credentials.username') != null ? System.getProperty('credentials.username') : "maven"
+ext.password = System.getProperty('credentials.password') != null ? System.getProperty('credentials.password') : "password"
 
 configurations {
     deployerJars
@@ -33,7 +66,7 @@ uploadArchives {
     repositories.mavenDeployer {
             configuration = configurations.deployerJars
             repository(url: "http://localhost:48080/storages/storage0/snapshots/") {
-                authentication(userName: usernams, password: password)
+                authentication(userName: username, password: password)
             }
             pom.groupId = "org.carlspring.strongbox.examples"
             pom.artifactId = "hello-strongbox-gradle"

--- a/hello-strongbox-gradle/gradle/wrapper/gradle-wrapper.properties
+++ b/hello-strongbox-gradle/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.11-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-all.zip


### PR DESCRIPTION
Refs strongbox/strongbox#1927

Published artifact: https://github.com/j4ckofalltrades/strongbox-examples/packages/472460?version=1.0-SNAPSHOT

Note: Not sure if adding a description to artifact is possible at this time, I read through the [maven-publish](https://docs.gradle.org/current/userguide/publishing_maven.html) and [GitHub docs](https://docs.github.com/en/free-pro-team@latest/packages/using-github-packages-with-your-projects-ecosystem/configuring-gradle-for-use-with-github-packages) but couldn't find anything.