### PR TITLE
Apply consistent naming to example artifacts

### DIFF
--- a/hello-strongbox-nuget-chocolatey/hello-chocolatey/hello-chocolatey.nuspec
+++ b/hello-strongbox-nuget-chocolatey/hello-chocolatey/hello-chocolatey.nuspec
@@ -23,7 +23,7 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
     <!-- This section is about this package, although id and version have ties back to the software -->
     <!-- id is lowercase and if you want a good separator for words, use '-', not '.'. Dots are only acceptable as suffixes for certain types of packages, e.g. .install, .portable, .extension, .template -->
     <!-- If the software is cross-platform, attempt to use the same id as the debian/rpm package(s) if possible. -->
-    <id>hello-chocolatey</id>
+    <id>hello-strongbox-nuget-chocolatey</id>
     <!-- version should MATCH as closely as possible with the underlying software -->
     <!-- Is the version a prerelease of a version? https://docs.nuget.org/create/versioning#creating-prerelease-packages -->
     <!-- Note that unstable versions like 0.0.1 can be considered a released version, but it's possible that one can release a 0.0.1-beta before you release a 0.0.1 version. If the version number is final, that is considered a released version and not a prerelease. -->
@@ -35,7 +35,7 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
 
     <!-- == SOFTWARE SPECIFIC SECTION == -->
     <!-- This section is about the software itself -->
-    <title>hello-chocolatey (Install)</title>
+    <title>hello-strongbox-nuget-chocolatey</title>
     <authors>Strongbox</authors>
     <!-- projectUrl is required for the community feed -->
     <projectUrl>https://github.com/strongbox/strongbox-examples/</projectUrl>

--- a/hello-strongbox-nuget-mono/Hello.Strongbox.Nuget.Mono.nuspec
+++ b/hello-strongbox-nuget-mono/Hello.Strongbox.Nuget.Mono.nuspec
@@ -2,7 +2,7 @@
 <!-- See nuspec file reference for full package metadata info - https://docs.microsoft.com/en-us/nuget/reference/nuspec -->
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
 	<metadata>
-		<id>Org.Carlspring.Strongbox.Examples.Nuget.Mono</id>
+		<id>hello-strongbox-nuget-mono</id>
 		<version>1.0.0</version>
 		<authors>Sergey Bespalov</authors>
 		<owners>Carlspring Consulting &amp; Development Ltd.</owners>

--- a/hello-strongbox-pypi/setup.py
+++ b/hello-strongbox-pypi/setup.py
@@ -4,7 +4,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(
-    name="hello-world-pypi",
+    name="hello-strongbox-pypi",
     packages = ['hello-world-pypi'],
     license='Apache 2.0',
     version="1.0.0",
@@ -13,8 +13,8 @@ setup(
     description="Sample Hello world package",
     long_description="This is long description",
     long_description_content_type="text/markdown",
-    url="https://github.com/anki2189/strongbox-examples",
-    keywords = ['Hello', 'world', 'pypi'],
+    url="https://github.com/strongbox/strongbox-examples",
+    keywords = ['strongbox', 'pypi'],
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',


### PR DESCRIPTION
All generated artifacts now follow the format
'hello-strongbox-[tool-goes-here]`.

Refs strongbox/strongbox#1927