### PR TITLE
Configure ci-friendly versions for mvn-based packages

### DIFF
--- a/.github/workflows/gh-registry.yml
+++ b/.github/workflows/gh-registry.yml
@@ -2,6 +2,22 @@ name: Publish strongbox-examples to the GitHub Package Registry
 on:
   [ push ]
 jobs:
+  publish-hello-strongbox-gradle:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - run: gradle build
+        working-directory: 'hello-strongbox-gradle'
+      # generate GitHub Package Registry ci-friendly version to avoid collision
+      - run: echo "GPR_VERSION=$(date '+%Y%m%d.%H%M')" >> $GITHUB_ENV
+      - run: gradle -Pgpr.version=$GPR_VERSION publish
+        working-directory: 'hello-strongbox-gradle'
+        env:
+          GITHUB_USERNAME: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   publish-hello-strongbox-nuget-choco:
     runs-on: ubuntu-latest
     steps:
@@ -32,20 +48,6 @@ jobs:
         working-directory: 'hello-strongbox-nuget-mono'
       - run: nuget push *.nupkg -SkipDuplicate
         working-directory: 'hello-strongbox-nuget-mono'
-  publish-hello-strongbox-gradle:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
-      - run: gradle build
-        working-directory: 'hello-strongbox-gradle'
-      - run: gradle publish
-        working-directory: 'hello-strongbox-gradle'
-        env:
-          GITHUB_USERNAME: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   publish-hello-strongbox-npm:
     runs-on: ubuntu-latest
     steps:

--- a/hello-strongbox-gradle/build.gradle
+++ b/hello-strongbox-gradle/build.gradle
@@ -13,6 +13,12 @@ compileJava {
 
 description = "Example project that shows how to use gradle to build and deploy artifacts to Strongbox"
 
+// GPR-friendly artifact version when deploying to GitHub Package Registry
+// The version string is generated via a GitHub action that deploys the artifact to the GitHub Package Registry
+// This is necessary as GitHub does not support overriding of published artifacts
+// See https://docs.github.com/en/free-pro-team@latest/packages/publishing-and-managing-packages/deleting-a-package#about-public-package-deletion
+ext.gprVersion = project.findProperty("gpr.version") ?: "1.0-SNAPSHOT"
+
 // publishing to GitHub Package Registry
 publishing {
     repositories {
@@ -20,9 +26,9 @@ publishing {
             name = "GitHubPackages"
             url = uri("https://maven.pkg.github.com/strongbox/strongbox-examples")
             credentials {
-                // GITHUB_USERNAME is automatically provived by the actions/setup-java action
+                // GITHUB_USERNAME is automatically provided by the actions/setup-java action
                 username = project.findProperty("gpr.user") ?: System.getenv("GITHUB_USERNAME")
-                // GITHUB_TOKEN is automatically provived by GitHub for every repository
+                // GITHUB_TOKEN is automatically provided by GitHub for every repository
                 password = project.findProperty("gpr.key") ?: System.getenv("GITHUB_TOKEN")
             }
         }
@@ -35,7 +41,7 @@ publishing {
 
             groupId = "org.carlspring.strongbox.examples"
             artifactId = "hello-strongbox-gradle"
-            version = "1.0-SNAPSHOT"
+            version = gprVersion
 
             from components.java
         }


### PR DESCRIPTION
Append `PACKAGE_REVISION` (timestamp in `yyyyMMdd-HHmm` format) to generated package version. This should be applied to all mvn-based packages.

Generated package: https://github.com/j4ckofalltrades/strongbox-examples/packages/472460

Refs strongbox/strongbox#1927